### PR TITLE
Add warning functionality regarding uploading supporting files for bug reporting phase

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@angular/platform-browser": "^11.2.14",
     "@angular/platform-browser-dynamic": "^11.2.14",
     "@angular/router": "^11.2.14",
+    "@apollo/client": "3.3.0",
     "@github/markdown-toolbar-element": "^2.1.1",
     "@octokit/rest": "^16.37.0",
     "ajv": "^6.11.0",
@@ -57,8 +58,7 @@
     "rxjs": "6.6.7",
     "tslib": "^2.0.0",
     "uuid": "7.0.3",
-    "zone.js": "~0.10.2",
-    "@apollo/client": "3.3.0"
+    "zone.js": "~0.10.2"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~0.1102.19",

--- a/src/app/phase-bug-reporting/new-issue/new-issue.component.html
+++ b/src/app/phase-bug-reporting/new-issue/new-issue.component.html
@@ -18,20 +18,25 @@
             [commentForm]="this.newIssueForm"
             [(isFormPending)]="this.isFormPending"
             [(submitButtonText)]="this.submitButtonText"
+            [(hasUploadedSupportingFile)]="this.hasUploadedSupportingFile"
           >
           </app-comment-editor>
         </div>
-
-        <button
-          style="float: right"
-          class="submit-new-bug-report"
-          type="submit"
-          mat-stroked-button
-          color="primary"
-          [disabled]="!newIssueForm.valid || isFormPending"
-        >
-          {{ this.submitButtonText }}
-        </button>
+        <div style="display: flex; align-items: center; justify-content: end">
+          <div *ngIf="!hasUploadedSupportingFile" style="display: flex; vertical-align: middle; flex-grow: 1">
+            <label for="understood">I understand and accept the risk of not uploading supporting files</label>
+            <input id="understood" type="checkbox" (change)="updateRequireUploadSupportingFile($event)" />
+          </div>
+          <button
+            class="submit-new-bug-report"
+            type="submit"
+            mat-stroked-button
+            color="primary"
+            [disabled]="!newIssueForm.valid || isFormPending || (requireUploadSupportingFile && !hasUploadedSupportingFile)"
+          >
+            {{ this.submitButtonText }}
+          </button>
+        </div>
       </div>
 
       <div class="column right">

--- a/src/app/phase-bug-reporting/new-issue/new-issue.component.ts
+++ b/src/app/phase-bug-reporting/new-issue/new-issue.component.ts
@@ -17,6 +17,8 @@ export class NewIssueComponent implements OnInit {
   newIssueForm: FormGroup;
   isFormPending = false;
   submitButtonText: string;
+  hasUploadedSupportingFile = false;
+  requireUploadSupportingFile = true;
 
   constructor(
     private issueService: IssueService,
@@ -35,6 +37,10 @@ export class NewIssueComponent implements OnInit {
     });
 
     this.submitButtonText = SUBMIT_BUTTON_TEXT.SUBMIT;
+  }
+
+  updateRequireUploadSupportingFile(event) {
+    this.requireUploadSupportingFile = !event.target.checked;
   }
 
   submitNewIssue(form: NgForm) {

--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -42,6 +42,10 @@ export class CommentEditorComponent implements OnInit {
   @Input() initialDescription?: string;
   placeholderText = 'No details provided.';
 
+  // Allows the comment editor to control the boolean whether any supporting files have been uploaded
+  @Input() hasUploadedSupportingFile?: boolean;
+  @Output() hasUploadedSupportingFileChange: EventEmitter<boolean> = new EventEmitter<boolean>();
+
   // Allows the comment editor to control the overall form's completeness.
   @Input() isFormPending?: boolean;
   @Output() isFormPendingChange: EventEmitter<boolean> = new EventEmitter<boolean>();
@@ -230,6 +234,7 @@ export class CommentEditorComponent implements OnInit {
             insertUploadUrl(filename, response.data.content.download_url, this.commentField, this.commentTextArea);
           }
           this.history.forceSave();
+          this.hasUploadedSupportingFileChange.emit(true);
         },
         (error) => {
           this.handleUploadError(error, insertedText);


### PR DESCRIPTION
# Description

This feature adds a warning functionality for the bug reporting phase. Motivation behind this feature is that it is difficult to ascertain the severity or presence of a bug if there are no supporting documents such as images showing the bug or log files. This warning and forced acknowledgement thus directly alerts students to this fact and how it only disadvantages them in proving their claims at a later phase.

### Without ticking checkbox
<img width="916" alt="image" src="https://github.com/Arif-Khalid/CATcher/assets/88131400/fb39883a-08a9-4006-ae4d-be3b0e601e61">

### With ticking checkbox
<img width="925" alt="image" src="https://github.com/Arif-Khalid/CATcher/assets/88131400/fc1f3234-2e77-4d10-a891-d323475bfbd0">

### With file uploaded
<img width="914" alt="image" src="https://github.com/Arif-Khalid/CATcher/assets/88131400/24c5649e-9194-4f9f-9b65-7421b6269389">

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

This has been tested locally on all file type submissions and works in the following manner.  
It prevent users from submission by disabling the submit button until either a supporting document has been successfully uploaded or they have ticked the checkbox, signaling they are aware of the risk involved by not doing any file uploads.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Note:

This change does not enforce that the link of the file upload remains in the description of the issue. Thus, uploading and subsequently removing the file from the description removes this acknowledgement check without the file being included in the issue.  
A way to remedy this is to store the description link(s) and check for they're existence on every input change. This however would significantly slow down the site. The cost outweighs the benefit.  
A better way would be to store the uploaded files in its own section outside of the description of the new issue, we would then include the appropriate links internally upon submission. See #2 