### PR TITLE
A separate section for file uploads in the comment editor

### DIFF
--- a/src/app/phase-bug-reporting/new-issue/new-issue.component.html
+++ b/src/app/phase-bug-reporting/new-issue/new-issue.component.html
@@ -13,6 +13,7 @@
 
         <div style="margin: 10px 0 10px 0">
           <app-comment-editor
+            #commentEditor
             [id]="'description'"
             [commentField]="description"
             [commentForm]="this.newIssueForm"

--- a/src/app/phase-bug-reporting/new-issue/new-issue.component.ts
+++ b/src/app/phase-bug-reporting/new-issue/new-issue.component.ts
@@ -7,7 +7,6 @@ import { ErrorHandlingService } from '../../core/services/error-handling.service
 import { IssueService } from '../../core/services/issue.service';
 import { LabelService } from '../../core/services/label.service';
 import { SUBMIT_BUTTON_TEXT } from '../../shared/view-issue/view-issue.component';
-import { CommentEditorComponent } from '../../shared/comment-editor/comment-editor.component';
 
 @Component({
   selector: 'app-new-issue',
@@ -19,7 +18,7 @@ export class NewIssueComponent implements OnInit {
   isFormPending = false;
   submitButtonText: string;
 
-  @ViewChild('commentEditor') commentEditor: CommentEditorComponent;
+  @ViewChild('commentEditor') commentEditor;
 
   constructor(
     private issueService: IssueService,

--- a/src/app/phase-bug-reporting/new-issue/new-issue.component.ts
+++ b/src/app/phase-bug-reporting/new-issue/new-issue.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
 import { AbstractControl, FormBuilder, FormGroup, NgForm, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { finalize } from 'rxjs/operators';
@@ -7,6 +7,7 @@ import { ErrorHandlingService } from '../../core/services/error-handling.service
 import { IssueService } from '../../core/services/issue.service';
 import { LabelService } from '../../core/services/label.service';
 import { SUBMIT_BUTTON_TEXT } from '../../shared/view-issue/view-issue.component';
+import { CommentEditorComponent } from '../../shared/comment-editor/comment-editor.component';
 
 @Component({
   selector: 'app-new-issue',
@@ -17,6 +18,8 @@ export class NewIssueComponent implements OnInit {
   newIssueForm: FormGroup;
   isFormPending = false;
   submitButtonText: string;
+
+  @ViewChild('commentEditor') commentEditor: CommentEditorComponent;
 
   constructor(
     private issueService: IssueService,
@@ -41,6 +44,7 @@ export class NewIssueComponent implements OnInit {
     if (this.newIssueForm.invalid) {
       return;
     }
+    this.commentEditor.onSubmit();
     this.isFormPending = true;
     this.issueService
       .createIssue(this.title.value, Issue.updateDescription(this.description.value), this.severity.value, this.type.value)

--- a/src/app/shared/comment-editor/comment-editor.component.html
+++ b/src/app/shared/comment-editor/comment-editor.component.html
@@ -1,5 +1,5 @@
 <form [formGroup]="commentForm" style="min-height: 350px" (ngSubmit)="onSubmit()">
-  <mat-tab-group class="mat-elevation-z1" animationDuration="0ms" (selectedTabChange)="commentField.setValue(commentTextArea.value)">
+  <mat-tab-group class="mat-elevation-z1" animationDuration="0ms" (selectedTabChange)="onTabChange($event)">
     <mat-tab label="Write">
       <div
         #dropArea
@@ -61,8 +61,8 @@
 
     <mat-tab label="Preview">
       <div class="tab-content" style="min-height: 228px">
-        <markdown #markdownArea *ngIf="commentField.value !== ''" [data]="sanitize(commentField.value)"></markdown>
-        <div *ngIf="commentField.value === ''">Nothing to preview.</div>
+        <markdown #markdownArea *ngIf="this.previewContent !== ''" [data]="sanitize(this.previewContent)"></markdown>
+        <div *ngIf="this.previewContent === ''">Nothing to preview.</div>
       </div>
     </mat-tab>
   </mat-tab-group>

--- a/src/app/shared/comment-editor/comment-editor.component.html
+++ b/src/app/shared/comment-editor/comment-editor.component.html
@@ -54,7 +54,11 @@
           </div>
         </mat-form-field>
       </div>
+      <div *ngFor="let fileName of fileNames">
+        <app-uploaded-file fileName="{{ fileName }}"></app-uploaded-file>
+      </div>
     </mat-tab>
+
     <mat-tab label="Preview">
       <div class="tab-content" style="min-height: 228px">
         <markdown #markdownArea *ngIf="commentField.value !== ''" [data]="sanitize(commentField.value)"></markdown>

--- a/src/app/shared/comment-editor/comment-editor.component.html
+++ b/src/app/shared/comment-editor/comment-editor.component.html
@@ -1,4 +1,4 @@
-<form [formGroup]="commentForm" style="min-height: 350px" (ngSubmit)="onSubmit()">
+<form [formGroup]="commentForm" style="min-height: 350px">
   <mat-tab-group class="mat-elevation-z1" animationDuration="0ms" (selectedTabChange)="onTabChange($event)">
     <mat-tab label="Write">
       <div

--- a/src/app/shared/comment-editor/comment-editor.component.html
+++ b/src/app/shared/comment-editor/comment-editor.component.html
@@ -54,8 +54,8 @@
           </div>
         </mat-form-field>
       </div>
-      <div *ngFor="let fileName of fileNames">
-        <app-uploaded-file fileName="{{ fileName }}"></app-uploaded-file>
+      <div *ngFor="let file of uploadedFiles">
+        <app-uploaded-file fileName="{{ file.displayName }}"></app-uploaded-file>
       </div>
     </mat-tab>
 

--- a/src/app/shared/comment-editor/comment-editor.component.html
+++ b/src/app/shared/comment-editor/comment-editor.component.html
@@ -1,4 +1,4 @@
-<form [formGroup]="commentForm" style="min-height: 350px">
+<form [formGroup]="commentForm" style="min-height: 350px" (ngSubmit)="onSubmit()">
   <mat-tab-group class="mat-elevation-z1" animationDuration="0ms" (selectedTabChange)="commentField.setValue(commentTextArea.value)">
     <mat-tab label="Write">
       <div
@@ -55,7 +55,7 @@
         </mat-form-field>
       </div>
       <div *ngFor="let file of uploadedFiles">
-        <app-uploaded-file fileName="{{ file.displayName }}"></app-uploaded-file>
+        <app-uploaded-file fileName="{{ file.displayName }}" (deleteFile)="deleteFile(file)"></app-uploaded-file>
       </div>
     </mat-tab>
 

--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -94,6 +94,21 @@ export class CommentEditorComponent implements OnInit {
     );
   }
 
+  deleteFile(uploadedFileToDelete: UploadedFile) {
+    console.log('Deleting ', uploadedFileToDelete.displayName);
+    this.uploadedFiles = this.uploadedFiles.filter((file) => file !== uploadedFileToDelete);
+  }
+
+  onSubmit() {
+    for (let file of this.uploadedFiles) {
+      if (this.uploadService.isVideoFile(file.displayName)) {
+        insertUploadUrlVideo(file.displayName, file.url, this.commentField, this.commentTextArea);
+      } else {
+        insertUploadUrl(file.displayName, file.url, this.commentField, this.commentTextArea);
+      }
+    }
+  }
+
   onKeyPress(event: KeyboardEvent) {
     if (UndoRedo.isUndo(event)) {
       event.preventDefault();

--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -6,7 +6,7 @@ import { UndoRedo } from '../../core/models/undoredo.model';
 import { ErrorHandlingService } from '../../core/services/error-handling.service';
 import { LoggingService } from '../../core/services/logging.service';
 import { FILE_TYPE_SUPPORT_ERROR, getSizeExceedErrorMsg, SUPPORTED_FILE_TYPES, UploadService } from '../../core/services/upload.service';
-import { insertContent, getContentToAppend } from './upload-text-insertor';
+import { getContentToAppend, insertContent } from './upload-text-insertor';
 import { UploadedFile } from './uploaded-file';
 
 const BYTES_PER_MB = 1024 * 1024;

--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -51,7 +51,9 @@ export class CommentEditorComponent implements OnInit {
   @Input() submitButtonText?: string;
   @Output() submitButtonTextChange: EventEmitter<string> = new EventEmitter<string>();
 
+  // The files uploaded kept separate from main content
   uploadedFiles: UploadedFile[] = [];
+  // Preview content is generated including uploaded file(s) if any before preview is shown
   previewContent: string;
 
   initialSubmitButtonText: string;
@@ -111,6 +113,7 @@ export class CommentEditorComponent implements OnInit {
     }
   }
 
+  // Insert content generated from uploaded files into the
   onSubmit() {
     insertContent(this.commentField, this.uploadedFiles);
   }
@@ -250,12 +253,6 @@ export class CommentEditorComponent implements OnInit {
       this.uploadService.uploadFile(reader.result, filename).subscribe(
         (response) => {
           this.uploadedFiles[this.uploadedFiles.length - 1].url = response.data.content.download_url;
-          // if (this.uploadService.isVideoFile(filename)) {
-          //   insertUploadUrlVideo(filename, response.data.content.download_url, this.commentField, this.commentTextArea);
-          // } else {
-          //   insertUploadUrl(filename, response.data.content.download_url, this.commentField, this.commentTextArea);
-          // }
-          // this.history.forceSave();
         },
         (error) => {
           this.handleUploadError(error);

--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -50,6 +50,8 @@ export class CommentEditorComponent implements OnInit {
   @Input() submitButtonText?: string;
   @Output() submitButtonTextChange: EventEmitter<string> = new EventEmitter<string>();
 
+  fileNames: string[] = [];
+
   initialSubmitButtonText: string;
   lastUploadingTime: string;
 

--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -7,6 +7,7 @@ import { ErrorHandlingService } from '../../core/services/error-handling.service
 import { LoggingService } from '../../core/services/logging.service';
 import { FILE_TYPE_SUPPORT_ERROR, getSizeExceedErrorMsg, SUPPORTED_FILE_TYPES, UploadService } from '../../core/services/upload.service';
 import { insertUploadingText, insertUploadUrl, insertUploadUrlVideo } from './upload-text-insertor';
+import { UploadedFile } from './uploaded-file';
 
 const BYTES_PER_MB = 1024 * 1024;
 const SHOWN_MAX_UPLOAD_SIZE_MB = 10;
@@ -50,7 +51,7 @@ export class CommentEditorComponent implements OnInit {
   @Input() submitButtonText?: string;
   @Output() submitButtonTextChange: EventEmitter<string> = new EventEmitter<string>();
 
-  fileNames: string[] = [];
+  uploadedFiles: UploadedFile[] = [];
 
   initialSubmitButtonText: string;
   lastUploadingTime: string;
@@ -199,20 +200,21 @@ export class CommentEditorComponent implements OnInit {
     this.uploadErrorMessage = null;
     const reader = new FileReader();
     const filename = file.name;
-    const insertedText = insertUploadingText(filename, this.commentField, this.commentTextArea);
+
+    this.uploadedFiles.push({ displayName: filename, url: '' });
 
     if (file.size >= MAX_UPLOAD_SIZE) {
-      this.handleUploadError(getSizeExceedErrorMsg('file', SHOWN_MAX_UPLOAD_SIZE_MB), insertedText);
+      this.handleUploadError(getSizeExceedErrorMsg('file', SHOWN_MAX_UPLOAD_SIZE_MB));
       return;
     }
 
     if (this.uploadService.isVideoFile(filename) && file.size >= MAX_VIDEO_UPLOAD_SIZE) {
-      this.handleUploadError(getSizeExceedErrorMsg('video', SHOWN_MAX_VIDEO_UPLOAD_SIZE_MB), insertedText);
+      this.handleUploadError(getSizeExceedErrorMsg('video', SHOWN_MAX_VIDEO_UPLOAD_SIZE_MB));
       return;
     }
 
     if (!this.uploadService.isSupportedFileType(filename)) {
-      this.handleUploadError(FILE_TYPE_SUPPORT_ERROR, insertedText);
+      this.handleUploadError(FILE_TYPE_SUPPORT_ERROR);
       return;
     }
 
@@ -226,15 +228,16 @@ export class CommentEditorComponent implements OnInit {
     reader.onload = () => {
       this.uploadService.uploadFile(reader.result, filename).subscribe(
         (response) => {
-          if (this.uploadService.isVideoFile(filename)) {
-            insertUploadUrlVideo(filename, response.data.content.download_url, this.commentField, this.commentTextArea);
-          } else {
-            insertUploadUrl(filename, response.data.content.download_url, this.commentField, this.commentTextArea);
-          }
-          this.history.forceSave();
+          this.uploadedFiles[this.uploadedFiles.length - 1].url = response.data.content.download_url;
+          // if (this.uploadService.isVideoFile(filename)) {
+          //   insertUploadUrlVideo(filename, response.data.content.download_url, this.commentField, this.commentTextArea);
+          // } else {
+          //   insertUploadUrl(filename, response.data.content.download_url, this.commentField, this.commentTextArea);
+          // }
+          // this.history.forceSave();
         },
         (error) => {
-          this.handleUploadError(error, insertedText);
+          this.handleUploadError(error);
           // Allow button enabling if this is the last file that was uploaded.
           if (currentFileUploadTime === this.lastUploadingTime) {
             this.updateParentFormsSubmittability(false, this.initialSubmitButtonText);
@@ -322,14 +325,14 @@ export class CommentEditorComponent implements OnInit {
     return !!this.uploadErrorMessage;
   }
 
-  private handleUploadError(error, insertedText: string) {
+  private handleUploadError(error) {
     if (error instanceof HttpErrorResponse) {
       this.errorHandlingService.handleError(error);
       this.uploadErrorMessage = 'Something went wrong while uploading your file. Please try again.';
     } else {
       this.uploadErrorMessage = error;
     }
-    this.commentField.setValue(this.commentField.value.replace(insertedText, ''));
+    this.uploadedFiles.pop();
     this.history.forceSave();
   }
 

--- a/src/app/shared/comment-editor/comment-editor.module.ts
+++ b/src/app/shared/comment-editor/comment-editor.module.ts
@@ -3,10 +3,11 @@ import { MarkdownModule } from 'ngx-markdown';
 import { SharedModule } from '../shared.module';
 import { CommentEditorComponent } from './comment-editor.component';
 import { MarkdownToolbarComponent } from './markdown-toolbar/markdown-toolbar.component';
+import { UploadedFileComponent } from './uploaded-file/uploaded-file.component';
 
 @NgModule({
   imports: [SharedModule, MarkdownModule.forChild()],
-  declarations: [CommentEditorComponent, MarkdownToolbarComponent],
+  declarations: [CommentEditorComponent, MarkdownToolbarComponent, UploadedFileComponent],
   exports: [CommentEditorComponent],
   schemas: [CUSTOM_ELEMENTS_SCHEMA]
 })

--- a/src/app/shared/comment-editor/upload-text-insertor.ts
+++ b/src/app/shared/comment-editor/upload-text-insertor.ts
@@ -1,7 +1,6 @@
 import { ElementRef } from '@angular/core';
 import { AbstractControl } from '@angular/forms';
 import { UploadedFile } from './uploaded-file';
-import { FieldsOnCorrectTypeRule } from 'graphql';
 
 export const DISPLAYABLE_CONTENT = ['gif', 'jpeg', 'jpg', 'png'];
 
@@ -56,7 +55,7 @@ function getInsertUrl(filename: string, uploadUrl: string) {
 // Get the content to append from the uploaded file array
 export function getContentToAppend(uploadedFiles: UploadedFile[]) {
   let contentToAppend = '';
-  for (let file of uploadedFiles) {
+  for (const file of uploadedFiles) {
     const fileType = file.displayName.split('.').pop();
     let prefix = '';
     if (DISPLAYABLE_CONTENT.includes(fileType.toLowerCase())) {
@@ -73,27 +72,4 @@ export function getContentToAppend(uploadedFiles: UploadedFile[]) {
 
 export function insertContent(commentField: AbstractControl, uploadedFiles: UploadedFile[]) {
   commentField.setValue(commentField.value.concat(getContentToAppend(uploadedFiles)));
-}
-
-function replacePlaceholderString(
-  filename: string,
-  insertedString: string,
-  commentField: AbstractControl,
-  commentTextArea: ElementRef<HTMLTextAreaElement>
-) {
-  const cursorPosition = commentTextArea.nativeElement.selectionEnd;
-  const insertingString = `[Uploading ${filename}...]`;
-  const startIndexOfString = commentField.value.indexOf(insertingString);
-  const endIndexOfString = startIndexOfString + insertingString.length;
-  const endOfInsertedString = startIndexOfString + insertedString.length;
-  const differenceInLength = endOfInsertedString - endIndexOfString;
-  const newCursorPosition =
-    cursorPosition > startIndexOfString - 1 && cursorPosition <= endIndexOfString // within the range of uploading text
-      ? endOfInsertedString
-      : cursorPosition < startIndexOfString // before the uploading text
-      ? cursorPosition
-      : cursorPosition + differenceInLength; // after the uploading text
-
-  commentField.setValue(commentField.value.replace(insertingString, insertedString));
-  commentTextArea.nativeElement.setSelectionRange(newCursorPosition, newCursorPosition);
 }

--- a/src/app/shared/comment-editor/upload-text-insertor.ts
+++ b/src/app/shared/comment-editor/upload-text-insertor.ts
@@ -40,17 +40,20 @@ export function insertUploadingText(
   return toInsert;
 }
 
+// Gets the markdown insertable url from the upload url for video
 function getInsertUrlVideo(uploadUrl: string) {
   const insertedString = `<i><video controls><source src="${uploadUrl}" type="video/mp4">Your browser does not support the video tag.</video><br>video:${uploadUrl}</i>`;
 
   return insertedString;
 }
 
+// Gets the markdown insertable url from the upload url for non-video files
 function getInsertUrl(filename: string, uploadUrl: string) {
   const insertedString = `[${filename}](${uploadUrl})`;
   return insertedString;
 }
 
+// Get the content to append from the uploaded file array
 export function getContentToAppend(uploadedFiles: UploadedFile[]) {
   let contentToAppend = '';
   for (let file of uploadedFiles) {

--- a/src/app/shared/comment-editor/upload-text-insertor.ts
+++ b/src/app/shared/comment-editor/upload-text-insertor.ts
@@ -1,5 +1,7 @@
 import { ElementRef } from '@angular/core';
 import { AbstractControl } from '@angular/forms';
+import { UploadedFile } from './uploaded-file';
+import { FieldsOnCorrectTypeRule } from 'graphql';
 
 export const DISPLAYABLE_CONTENT = ['gif', 'jpeg', 'jpg', 'png'];
 
@@ -38,29 +40,31 @@ export function insertUploadingText(
   return toInsert;
 }
 
-export function insertUploadUrlVideo(
-  filename: string,
-  uploadUrl: string,
-  commentField: AbstractControl,
-  commentTextArea: ElementRef<HTMLTextAreaElement>
-) {
+function getInsertUrlVideo(uploadUrl: string) {
   const insertedString = `<i><video controls><source src="${uploadUrl}" type="video/mp4">Your browser does not support the video tag.</video><br>video:${uploadUrl}</i>`;
 
-  appendToContent(insertedString, commentField);
+  return insertedString;
 }
 
-export function insertUploadUrl(
-  filename: string,
-  uploadUrl: string,
-  commentField: AbstractControl,
-  commentTextArea: ElementRef<HTMLTextAreaElement>
-) {
+function getInsertUrl(filename: string, uploadUrl: string) {
   const insertedString = `[${filename}](${uploadUrl})`;
-  appendToContent(insertedString, commentField);
+  return insertedString;
 }
 
-function appendToContent(contentToAppend: string, commentField: AbstractControl) {
-  commentField.setValue(commentField.value.concat(`${contentToAppend}\n`));
+export function getContentToAppend(uploadedFiles: UploadedFile[]) {
+  let contentToAppend = '';
+  for (let file of uploadedFiles) {
+    if (file.isVideo) {
+      contentToAppend = contentToAppend.concat(getInsertUrlVideo(file.url) + '  \n');
+    } else {
+      contentToAppend = contentToAppend.concat(getInsertUrl(file.displayName, file.url) + '  \n');
+    }
+  }
+  return contentToAppend;
+}
+
+export function insertContent(commentField: AbstractControl, uploadedFiles: UploadedFile[]) {
+  commentField.setValue(commentField.value.concat(getContentToAppend(uploadedFiles)));
 }
 
 function replacePlaceholderString(

--- a/src/app/shared/comment-editor/upload-text-insertor.ts
+++ b/src/app/shared/comment-editor/upload-text-insertor.ts
@@ -46,7 +46,7 @@ export function insertUploadUrlVideo(
 ) {
   const insertedString = `<i><video controls><source src="${uploadUrl}" type="video/mp4">Your browser does not support the video tag.</video><br>video:${uploadUrl}</i>`;
 
-  replacePlaceholderString(filename, insertedString, commentField, commentTextArea);
+  appendToContent(insertedString, commentField);
 }
 
 export function insertUploadUrl(
@@ -56,7 +56,11 @@ export function insertUploadUrl(
   commentTextArea: ElementRef<HTMLTextAreaElement>
 ) {
   const insertedString = `[${filename}](${uploadUrl})`;
-  replacePlaceholderString(filename, insertedString, commentField, commentTextArea);
+  appendToContent(insertedString, commentField);
+}
+
+function appendToContent(contentToAppend: string, commentField: AbstractControl) {
+  commentField.setValue(commentField.value.concat(`${contentToAppend}\n`));
 }
 
 function replacePlaceholderString(

--- a/src/app/shared/comment-editor/upload-text-insertor.ts
+++ b/src/app/shared/comment-editor/upload-text-insertor.ts
@@ -54,10 +54,15 @@ function getInsertUrl(filename: string, uploadUrl: string) {
 export function getContentToAppend(uploadedFiles: UploadedFile[]) {
   let contentToAppend = '';
   for (let file of uploadedFiles) {
+    const fileType = file.displayName.split('.').pop();
+    let prefix = '';
+    if (DISPLAYABLE_CONTENT.includes(fileType.toLowerCase())) {
+      prefix = '!';
+    }
     if (file.isVideo) {
-      contentToAppend = contentToAppend.concat(getInsertUrlVideo(file.url) + '  \n');
+      contentToAppend = contentToAppend.concat(prefix + getInsertUrlVideo(file.url) + '  \n');
     } else {
-      contentToAppend = contentToAppend.concat(getInsertUrl(file.displayName, file.url) + '  \n');
+      contentToAppend = contentToAppend.concat(prefix + getInsertUrl(file.displayName, file.url) + '  \n');
     }
   }
   return contentToAppend;

--- a/src/app/shared/comment-editor/uploaded-file.ts
+++ b/src/app/shared/comment-editor/uploaded-file.ts
@@ -1,4 +1,5 @@
 export type UploadedFile = {
   displayName: string;
   url: string;
+  isVideo: boolean;
 };

--- a/src/app/shared/comment-editor/uploaded-file.ts
+++ b/src/app/shared/comment-editor/uploaded-file.ts
@@ -1,0 +1,4 @@
+export type UploadedFile = {
+  displayName: string;
+  url: string;
+};

--- a/src/app/shared/comment-editor/uploaded-file/uploaded-file.component.html
+++ b/src/app/shared/comment-editor/uploaded-file/uploaded-file.component.html
@@ -1,0 +1,1 @@
+<p>{{ this.fileName }}</p>

--- a/src/app/shared/comment-editor/uploaded-file/uploaded-file.component.html
+++ b/src/app/shared/comment-editor/uploaded-file/uploaded-file.component.html
@@ -1,1 +1,6 @@
-<p>{{ this.fileName }}</p>
+<div style="display: flex; justify-content: space-between; margin: 0.5rem">
+  <p>{{ fileName }}</p>
+  <button type="button" mat-icon-button (click)="onDelete()" disableRipple="true" matTooltip="Delete this file">
+    <mat-icon>delete</mat-icon>
+  </button>
+</div>

--- a/src/app/shared/comment-editor/uploaded-file/uploaded-file.component.ts
+++ b/src/app/shared/comment-editor/uploaded-file/uploaded-file.component.ts
@@ -1,0 +1,13 @@
+import { Component, EventEmitter, Input, OnInit, Output, ViewChild, ViewContainerRef } from '@angular/core';
+@Component({
+  selector: 'app-uploaded-file',
+  templateUrl: './uploaded-file.component.html',
+  styleUrls: ['./uploaded-file.component.css'],
+  providers: []
+})
+export class UploadedFileComponent implements OnInit {
+  @Input() fileName: string;
+  @Input() uploading = false;
+
+  ngOnInit(): void {}
+}

--- a/src/app/shared/comment-editor/uploaded-file/uploaded-file.component.ts
+++ b/src/app/shared/comment-editor/uploaded-file/uploaded-file.component.ts
@@ -8,6 +8,11 @@ import { Component, EventEmitter, Input, OnInit, Output, ViewChild, ViewContaine
 export class UploadedFileComponent implements OnInit {
   @Input() fileName: string;
   @Input() uploading = false;
+  @Output() deleteFile: EventEmitter<void> = new EventEmitter();
 
   ngOnInit(): void {}
+
+  onDelete() {
+    this.deleteFile.emit();
+  }
 }


### PR DESCRIPTION
# Description

Separates the file uploads from the content description in the comment editor component.  
Motivation behind this is for a more clean and readable description interface, making it easier and simpler for people to use CATcher, especially if unfamiliar with markdown syntax for referencing links.  
Uploaded files can still be previewed, however editing after new issue creation allows users to see and edit the markdown syntax for linking content.  
This pull request is a follow up from #1 where it would be useful to ascertain whether a user has uploaded a file. 

### Uploading files
<img width="920" alt="image" src="https://github.com/Arif-Khalid/CATcher/assets/88131400/ba02492d-4a60-4817-bcbd-765fbc52d632">

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

The change has been tested locally with all accepted file types specifically on the bug reporting phase, using the comment editor in **creating** issues.  

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Note
**Currently all other file uploads aside from new issue creation in the bug reporting phase will not work in this branch due to this breaking change**
From what I researched, I cannot access the onSubmit function of the form group from the inner form group present in the comment editor, thus requiring me to manually get a reference to and call the onSubmit function on the comment editor from all parents of comment editor in order for this feature to work.  
Open to any suggestions for better ways of implementation.  
As an experimental change, I therefore have decided not to refactor such a significant amount of the code base before getting the go ahead, thus, this feature is only showcased on the new issue component creation in the bug reporting phase.  
Tests fail because of the refactoring of the upload-text-inserter of the comment editor to be optimized for the newly implemented way of upload.  
Another issue is editing files after issue creation will show the same markdown syntax of linking content, if deemed significant, would have to parse the content beforehand to get the file names and urls back. This would be a daunting task with unbounded possibilities for user's file names.

